### PR TITLE
Update README for MinGW users

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,6 @@ If you download the code from GitHub via the "Download ZIP" approach, you'll als
 From a command prompt in the `GLFW-CMake-starter` directory:
 1. `mkdir build`
 1. `cd build`
-1. `cmake ..`
+1. `cmake ..` (to specify build system generator, use -G option, e.g. for MinGW: `cmake .. -G "MinGW Makefiles`)
 1. Either run `make all` or for Visual Studio open `GLFW-CMake-starter.sln` or for MinGW run `mingw32-make`
 

--- a/README.md
+++ b/README.md
@@ -36,5 +36,5 @@ From a command prompt in the `GLFW-CMake-starter` directory:
 1. `mkdir build`
 1. `cd build`
 1. `cmake ..`
-1. Either run `make all` or for Visual Studio open `GLFW-CMake-starter.sln`
+1. Either run `make all` or for Visual Studio open `GLFW-CMake-starter.sln` or for MinGW run `mingw32-make`
 


### PR DESCRIPTION
It might not be obvious for new C++ users that use MinGW on Windows that they should run mingw32-make to execute Makefile.