### PR TITLE
Include glad in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ include_directories( ${OPENGL_INCLUDE_DIRS} )
 
 set( GLFW_BUILD_DOCS OFF CACHE BOOL  "GLFW lib only" )
 set( GLFW_INSTALL OFF CACHE BOOL  "GLFW lib only" )
-set( GLAD_GL "${GLFW_SOURCE_DIR}/deps/glad/gl.h"  "${GLFW_SOURCE_DIR}/deps/glad_gl.c" )
+set( GLAD_GL "" )
 
 add_subdirectory( glfw )
 
@@ -16,6 +16,7 @@ option( GLFW-CMAKE-STARTER-USE-GLFW-GLAD "Use GLAD from GLFW" ON )
 
 if( GLFW-CMAKE-STARTER-USE-GLFW-GLAD )
     include_directories("${GLFW_SOURCE_DIR}/deps")
+    set( GLAD_GL "${GLFW_SOURCE_DIR}/deps/glad/gl.h" )
 endif()
 
 if( MSVC )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,12 @@ set( GLFW_INSTALL OFF CACHE BOOL  "GLFW lib only" )
 set( GLAD_GL "${GLFW_SOURCE_DIR}/deps/glad/gl.h"  "${GLFW_SOURCE_DIR}/deps/glad_gl.c" )
 
 add_subdirectory( glfw )
-include_directories("${GLFW_SOURCE_DIR}/deps")
+
+option( GLFW-CMAKE-STARTER-USE-GLFW-GLAD "Use GLAD from GLFW" ON )
+
+if( GLFW-CMAKE-STARTER-USE-GLFW-GLAD )
+    include_directories("${GLFW_SOURCE_DIR}/deps")
+endif()
 
 if( MSVC )
     SET( CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /ENTRY:mainCRTStartup" )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,21 +8,23 @@ include_directories( ${OPENGL_INCLUDE_DIRS} )
 
 set( GLFW_BUILD_DOCS OFF CACHE BOOL  "GLFW lib only" )
 set( GLFW_INSTALL OFF CACHE BOOL  "GLFW lib only" )
+set( GLAD_GL "${GLFW_SOURCE_DIR}/deps/glad/gl.h"  "${GLFW_SOURCE_DIR}/deps/glad_gl.c" )
 
 add_subdirectory( glfw )
+include_directories("${GLFW_SOURCE_DIR}/deps")
 
 if( MSVC )
     SET( CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /ENTRY:mainCRTStartup" )
 endif()
 
 set( GLFW-CMAKE-STARTER-SRC
-     main.cpp
-     )
-     
-add_executable( GLFW-CMake-starter WIN32 ${GLFW-CMAKE-STARTER-SRC} )
+        main.cpp
+        )
+
+add_executable( GLFW-CMake-starter WIN32 ${GLFW-CMAKE-STARTER-SRC} ${GLAD_GL} )
 target_link_libraries( GLFW-CMake-starter ${OPENGL_LIBRARIES} glfw )
 if( MSVC )
-    if(${CMAKE_VERSION} VERSION_LESS "3.6.0") 
+    if(${CMAKE_VERSION} VERSION_LESS "3.6.0")
         message( "\n\t[ WARNING ]\n\n\tCMake version lower than 3.6.\n\n\t - Please update CMake and rerun; OR\n\t - Manually set 'GLFW-CMake-starter' as StartUp Project in Visual Studio.\n" )
     else()
         set_property( DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT GLFW-CMake-starter )


### PR DESCRIPTION
This change allows the user to run the [quick example](https://www.glfw.org/docs/latest/quick_guide.html#quick_example) from GLFW documentation